### PR TITLE
Better GC handling

### DIFF
--- a/src/NVTX.jl
+++ b/src/NVTX.jl
@@ -261,7 +261,7 @@ const GC_ATTR = Ref(event_attributes()[1])
 function gc_cb_pre(full::Cint)
     # ideally we would pass `full` as a payload, but this causes allocations and
     # causes a problem when testing with threads
-    range_push(GC_DOMAIN[], GC_ATTR[])
+    range_push(GC_DOMAIN[]; category=reinterpret(UInt32, full))
     return nothing
 end
 function gc_cb_post(full::Cint)

--- a/src/NVTX.jl
+++ b/src/NVTX.jl
@@ -60,7 +60,6 @@ struct EventAttributes
     payload::UInt64
     messagetype::Int32
     message::Ptr{Cvoid}
-    messageref # for GC
 end
 
 payloadtype(::Nothing) = 0
@@ -107,7 +106,6 @@ function EventAttributes(;
         payloadval(payload),      # payload
         isnothing(message) ? 0 : message isa StringHandle ? 3 : 1,      # messagetype
         isnothing(message) ? C_NULL : message isa StringHandle ? message.ptr : Base.unsafe_convert(Cstring, message), # message
-        message,
     )
 end
 

--- a/test/basic.jl
+++ b/test/basic.jl
@@ -23,7 +23,8 @@ Threads.@threads for i = 1:5
     NVTX.range_pop(domain)
 end
 
-GC.gc()
+GC.gc(false)
+GC.gc(true)
 
 NVTX.mark(domain; message=NVTX.StringHandle(domain, "mark 2"), category=2, payload=1.2)
 


### PR DESCRIPTION
Remove allocations when using kwargs, make StringHandles play nice, and label GC categories